### PR TITLE
Using default naming  functionality to generate index names. sqlite is

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
@@ -76,7 +76,7 @@ class CreateSchemaListener implements EventSubscriber
             $pkColumns = $entityTable->getPrimaryKey()->getColumns();
             $pkColumns[] = $this->config->getRevisionFieldName();
             $revisionTable->setPrimaryKey($pkColumns);
-            $revisionTable->addIndex(array($this->config->getRevisionFieldName()),$this->config->getRevisionFieldName().'Index');
+            $revisionTable->addIndex(array($this->config->getRevisionFieldName()));
         }
     }
 


### PR DESCRIPTION
not able to genearte an index with the same name over different tables
